### PR TITLE
Made "Feature Toggle" plural in the first sentence so it fits better …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Flip - A feature toggling framework
 
-Flip makes it simple to use [Feature Toggle](http://martinfowler.com/bliki/FeatureToggle.html),
+Flip makes it simple to use [Feature Toggles](http://martinfowler.com/bliki/FeatureToggle.html),
 (also known as Feature Flags, Feature Bits, Feature Switches, etc) in your Java application.
 
 Feature toggles can be used for many purposes, including:
@@ -8,7 +8,7 @@ Feature toggles can be used for many purposes, including:
 1. Reducing the need to branch by feature in your source control system by having all work done on the main code line.
    Features that are not ready for production can simply be disabled.
 2. New features can be rolled out to a subset of users (e.g. by group membership, canary testing, etc)
-2. Should a feature become problematic, we can turn it off without requiring a build and deploy.
+2. Should a feature become problematic, you can turn it off without requiring a build and deploy.
 
 # Start Using Flip
 
@@ -21,7 +21,7 @@ Flip is available in Maven Central under the following identifiers:
 If you're using Ant we recommend that you use Apache Ivy. If you can't do that for whatever reason, take a look at our
 [instructions for installation under Ant](https://github.com/tacitknowledge/flip/wiki/Installation-under-Ant).
 
-The quickest way to understand how to use Flip is by looking in at the [examples](https://github.com/tacitknowledge/flip/tree/master/examples).
+The quickest way to understand how to use Flip is by looking at the [examples](https://github.com/tacitknowledge/flip/tree/master/examples).
 
 # Documentation
 
@@ -29,13 +29,12 @@ The documentation for Flip is on the [Flip Wiki](https://github.com/tacitknowled
 
 # Licensing
 
-This framework is released under Apache 2.0 Public License. The text of the
-license you can find at http://www.apache.org/licenses/LICENSE-2.0.txt.
+This framework is released under Apache 2.0 Public License. You can find the license text at http://www.apache.org/licenses/LICENSE-2.0.txt.
 
 ## Contributing
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Added some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+4. Push to the remote branch (`git push origin my-new-feature`)
+5. Create a new Pull Request


### PR DESCRIPTION
…with the rest of the sentence. In the description of feature toggle uses, changed "we" to "you" in item #3 to match the descriptions in the other two list items. Under "Licensing", change the phrase"The text of the license you can find at" to "You can find the license text at" so it reads smoother. Under "Contributing" changed item #4 from "Push to the branch" to "Push to the remote branch" to make the goal clearer, and item #5 from "Create new Pull Request" to "Create a new Pull Request" so it reads better.